### PR TITLE
Remove Bracket Pair Colorizer extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "vivaxy.vscode-conventional-commits",
-    "coenraads.bracket-pair-colorizer",
     "dsznajder.es7-react-js-snippets",
     "mhutchie.git-graph",
     "oderwat.indent-rainbow"


### PR DESCRIPTION
This is now natively implemented as of VSCode 1.6 https://code.visualstudio.com/updates/v1_60#_high-performance-bracket-pair-colorization